### PR TITLE
re-added custom class to architecture image for resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 							<h2>Arroyo</h2>
 							<h2>Arroyo</h2>
               <p>Arroyo is a lightweight framework that facilitates the granular rehydration of logs, granting users the ability to select a specific timeframe to search for relevant log files. </p>
-              <img class="image " src="images/technical-img/architecture.gif" alt="Arroyo architecture" data-position="center center" />
+              <img class="image home-page-architecture-image" src="images/technical-img/architecture.gif" alt="Arroyo architecture" data-position="center center" />
 						</div>
             <ul class="actions case-study-btn">
               <li><a href="case-study.html" class="button scrolly">Read Case Study</a></li>


### PR DESCRIPTION
Reason:
During one of the merges on Friday, the main architecture image was no longer resizing.
Thankfully all of the custom styling was preserved in the css files.

The fix was to re-add the ```home-page-architecture-image``` class back to the image.
