### PR TITLE
changed Arroyo title to helvetica

### DIFF
--- a/assets/css/home-animation.css
+++ b/assets/css/home-animation.css
@@ -13,12 +13,14 @@
   this is a fix:
   */
   margin-left: 50%;
+  font-family: helvetica;
 }
 
 .arroyo-title h2:nth-child(1) {
   color: transparent;
   margin-left: 50%;
   -webkit-text-stroke: 2px #03a9f4;
+  font-family: helvetica;
 }
 
 .arroyo-title h2:nth-child(2) {


### PR DESCRIPTION
Changes Made:

- updated the font for the ```<h2>``` titles on the main page to fix artifacts that ```Nunito``` font was producing.

Before:
<img width="473" alt="Screen Shot 2022-08-25 at 11 38 54 AM" src="https://user-images.githubusercontent.com/71610961/186758339-69bf22d8-df38-47f8-a142-9913cc574735.png">

After:
<img width="509" alt="Screen Shot 2022-08-25 at 1 03 48 PM" src="https://user-images.githubusercontent.com/71610961/186758356-82b8c028-bcb8-4471-b0f8-32e705e84e85.png">

Closes #77 


